### PR TITLE
Edited pack workflow triggers and enabled manual pack.

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
     - master
+    paths:
+    - '**.nuspec'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Pack workflow only starts if nuspecs have been edited, and can be manually triggered in GitHub.